### PR TITLE
[EOS] Increase default eapi connector timeout

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,4 @@
-pytest>=3.0.1
+pytest==3.6.3
 flake8>=3.0.0
 mock
 pytest-cov

--- a/pylib/aeon/eos/connector.py
+++ b/pylib/aeon/eos/connector.py
@@ -41,7 +41,8 @@ class Connector(object):
         else:
             self.eapi = pyeapi.connect(
                 transport=self.proto, host=self.hostname,
-                username=self.user, password=self.passwd)
+                username=self.user, password=self.passwd,
+                timeout=120)
 
     def execute(self, commands, encoding='json'):
 

--- a/tests/test_eos.py
+++ b/tests/test_eos.py
@@ -158,6 +158,6 @@ def test_eos_connector_configure(mock_eapi):
 
     con = connector.Connector(target, user=user, passwd=passwd)
     con.configure(['test1', 'test2', ''])
-    expected = [mock.call(host=target, password=passwd, transport='http', username=user),
+    expected = [mock.call(host=target, password=passwd, transport='http', username=user, timeout=120),
                 mock.call().execute(['enable', 'configure', 'test1', 'test2'])]
     assert mock_eapi.mock_calls == expected


### PR DESCRIPTION
Realized there are some command taking long time to execute e.g. install source <path> to perform an image upgrade. Since the connection is shared among multiple commands, and python eapi doesn't provide an override per command, setting defensively a longer to deal with slow but critical commands like the example above.